### PR TITLE
Added ability to start searching from a specified root directory

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,8 @@
 # find-nearest-file
 
-Lookup a filename starting in `process.cwd()`, then `../`, `../../`, all the way
-up to the filesystem root. Returns the found file path or `null`.
+Lookup a filename starting in `process.cwd()` or a specified root directory,
+then `../`, `../../`, all the way up to the filesystem root. Returns then
+found file path or `null`.
 
 ## Installation
 
@@ -14,6 +15,7 @@ npm install --save find-nearest-file
 ```js
 var findNearestFile = require('find-nearest-file')
 var file = findNearestFile('.localconfigrc')
+var otherfile = findNearestFile('.localconfigrc', '/start/search/from/here')
 ```
 
 ## Credits

--- a/find-nearest-file.js
+++ b/find-nearest-file.js
@@ -3,13 +3,16 @@ module.exports = find
 var fs = require('fs')
   , path = require('path')
 
-function find(filename) {
+function find(filename, root) {
+
+  root = root || process.cwd();
 
   if (!filename) throw new Error('filename is required')
 
   if (filename.indexOf('/') !== -1 || filename === '..') {
     throw new Error('filename must be just a filename and not a path')
   }
+
 
   function findFile(directory, filename) {
 
@@ -33,6 +36,6 @@ function find(filename) {
 
   }
 
-  return findFile(process.cwd(), filename)
+  return findFile(root, filename)
 
 }

--- a/test/find-nearest-file.test.js
+++ b/test/find-nearest-file.test.js
@@ -67,4 +67,22 @@ describe('find-nearest-file', function () {
 
   })
 
+  it('should start searching at a different root directory, if provided', function () {
+
+    var find = rewire('../')
+      , filename = 'a-really-unique-filename-for-testing.test.zzz.__dsf.yup'
+      , paths = []
+
+    function mockStat(path) {
+      paths.push(path)
+      throw new Error()
+    }
+
+    find.__set__('fs', { statSync: mockStat })
+    find(filename, '/')
+    assert.equal(paths.length, 1)
+    assert.equal(paths[0], '/' + filename)
+
+  })
+
 })


### PR DESCRIPTION
Pass in a directory as the second parameter and `find-nearest-file`
will start it's search there. This defaults to `process.cwd()`.

Additionally, I added a test for this functionality.
